### PR TITLE
Provide a read-only API for product config

### DIFF
--- a/src/main/java/fi/fmi/avi/archiver/initializing/AviationProductBuildersHolder.java
+++ b/src/main/java/fi/fmi/avi/archiver/initializing/AviationProductBuildersHolder.java
@@ -1,0 +1,69 @@
+package fi.fmi.avi.archiver.initializing;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import fi.fmi.avi.archiver.initializing.AviationProductsHolder.AviationProduct;
+import fi.fmi.avi.archiver.initializing.AviationProductsHolder.FileConfig;
+import fi.fmi.avi.model.GenericAviationWeatherMessage;
+
+/**
+ * Holder for Aviation product builders.
+ * This is required to let Spring Boot populate values from application config.
+ * {@link AviationProductsHolder} class holds the built immutable configuration objects.
+ */
+@Component
+@ConfigurationProperties(prefix = "production-line-initialization")
+class AviationProductBuildersHolder {
+
+    @Resource(name = "messageRouteIds")
+    private Map<String, Integer> messageRouteIds;
+    @Resource(name = "messageFormatIds")
+    private Map<GenericAviationWeatherMessage.Format, Integer> messageFormatIds;
+
+    private List<AviationProduct.Builder> products = Collections.emptyList();
+
+    public AviationProductBuildersHolder() {
+    }
+
+    public List<AviationProduct.Builder> getProducts() {
+        return products;
+    }
+
+    public void setProducts(final List<AviationProduct.Builder> products) {
+        this.products = products;
+    }
+
+    @PostConstruct
+    private void mapRoutesToIds() {
+        AviationProductsHolder.iterateProducts(products, product -> {
+            final Integer routeId = messageRouteIds.get(product.getRoute());
+            if (routeId == null) {
+                throw new IllegalStateException(String.format(Locale.ROOT, "Unknown route <%s> for product <%s>", product.getRoute(), product.getId()));
+            }
+            product.setRouteId(routeId);
+        });
+    }
+
+    @PostConstruct
+    private void mapFormatsToIds() {
+        AviationProductsHolder.iterateProducts(products, product -> {
+            for (final FileConfig.Builder file : product.getFiles()) {
+                final Integer formatId = messageFormatIds.get(file.getFormat());
+                if (formatId == null) {
+                    throw new IllegalStateException(
+                            String.format(Locale.ROOT, "Unknown file message format <%s> for product <%s>", file.getFormat(), product.getId()));
+                }
+                file.setFormatId(formatId);
+            }
+        });
+    }
+}

--- a/src/main/java/fi/fmi/avi/archiver/initializing/AviationProductsHolder.java
+++ b/src/main/java/fi/fmi/avi/archiver/initializing/AviationProductsHolder.java
@@ -1,23 +1,19 @@
 package fi.fmi.avi.archiver.initializing;
 
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.Resource;
-
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.inferred.freebuilder.FreeBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import com.google.common.base.Strings;
 
 import fi.fmi.avi.model.GenericAviationWeatherMessage;
 
@@ -25,206 +21,100 @@ import fi.fmi.avi.model.GenericAviationWeatherMessage;
  * Holder for Aviation products.
  */
 @Component
-@ConfigurationProperties(prefix = "production-line-initialization")
 public class AviationProductsHolder {
+    private final List<AviationProduct> products;
 
-    @Resource(name = "messageRouteIds")
-    private Map<String, Integer> messageRouteIds;
-    @Resource(name = "messageFormatIds")
-    private Map<GenericAviationWeatherMessage.Format, Integer> messageFormatIds;
-
-    private List<AviationProduct> products = Collections.emptyList();
-
-    public AviationProductsHolder() {
+    public AviationProductsHolder(@Autowired final AviationProductBuildersHolder aviationProductBuildersHolder) {
+        requireNonNull(aviationProductBuildersHolder, "aviationProductBuildersHolder");
+        products = buildProducts(aviationProductBuildersHolder.getProducts());
     }
 
-    public AviationProductsHolder(final List<AviationProduct> products) {
-        this.products = Collections.unmodifiableList(products);
+    public static <E> void iterateProducts(final List<E> productBuilders, final Consumer<? super E> productConsumer) {
+        final int size = productBuilders.size();
+        for (int i = 0; i < size; i++) {
+            try {
+                productConsumer.accept(productBuilders.get(i));
+            } catch (final RuntimeException e) {
+                throw new IllegalStateException("Product at index <" + i + "> is invalid", e);
+            }
+        }
+    }
+
+    private List<AviationProduct> buildProducts(final List<AviationProduct.Builder> productBuilders) {
+        checkState(!productBuilders.isEmpty(), "Products are missing");
+        final int size = productBuilders.size();
+        final List<AviationProduct> builder = new ArrayList<>(size);
+        iterateProducts(productBuilders, product -> builder.add(product.build()));
+        return Collections.unmodifiableList(builder);
     }
 
     public List<AviationProduct> getProducts() {
-        return Collections.unmodifiableList(products);
+        return products;
     }
 
-    public void setProducts(final List<AviationProduct> products) {
-        this.products = Collections.unmodifiableList(products);
-    }
-
-    @PostConstruct
-    private void mapRoutesToIds() {
-        for (final AviationProduct product : products) {
-            final Integer routeId = messageRouteIds.get(product.getRoute());
-            if (routeId == null) {
-                throw new IllegalStateException(String.format(Locale.ROOT, "Unknown route <%s> for product <%s>", product.getRoute(), product.getId()));
-            }
-            product.setRouteId(routeId);
+    @FreeBuilder
+    public abstract static class AviationProduct {
+        AviationProduct() {
         }
-    }
 
-    @PostConstruct
-    private void mapFormatsToIds() {
-        for (final AviationProduct product : products) {
-            for (final FileConfig file : product.getFiles()) {
-                final Integer formatId = messageFormatIds.get(file.getFormat());
-                if (formatId == null) {
-                    throw new IllegalStateException(
-                            String.format(Locale.ROOT, "Unknown file message format <%s> for product <%s>", file.getFormat(), product.getId()));
-                }
-                file.setFormatId(formatId);
+        public abstract String getId();
+
+        public abstract String getRoute();
+
+        public abstract int getRouteId();
+
+        public abstract File getInputDir();
+
+        public abstract File getArchiveDir();
+
+        public abstract File getFailDir();
+
+        public abstract List<FileConfig> getFileConfigs();
+
+        public static class Builder extends AviationProductsHolder_AviationProduct_Builder {
+            public Builder() {
             }
-        }
-    }
 
-    @PostConstruct
-    private void checkProductPropertiesHaveValues() {
-        for (int productIndex = 0; productIndex < products.size(); productIndex++) {
-            final AviationProduct product = products.get(productIndex);
-            checkState(Strings.emptyToNull(product.getId()) != null, "Product at index <%s> is missing id", productIndex);
-            checkState(Strings.emptyToNull(product.getRoute()) != null, "Product <%s> is missing route", product.getId());
-            checkState(product.getInputDir() != null, "Product <%s> is missing inputDir", product.getId());
-            checkState(product.getArchiveDir() != null, "Product <%s> is missing archiveDir", product.getId());
-            checkState(product.getFailDir() != null, "Product <%s> is missing failDir", product.getId());
-            final List<FileConfig> files = product.getFiles();
-            checkState(!files.isEmpty(), "Product <%s> is missing files", product.getId());
-            for (int fileIndex = 0; fileIndex < files.size(); fileIndex++) {
-                final FileConfig file = files.get(fileIndex);
-                checkState(file.getPattern() != null && !file.getPattern().toString().isEmpty(), "Product <%s> file config at index <%s> is missing pattern",
-                        product.getId(), fileIndex);
-                checkState(file.getNameTimeZone() != null, "Product <%s> file config at index <%s> is missing nameTimeZone", product.getId(), fileIndex);
-                checkState(file.getFormat() != null, "Product <%s> file config at index <%s> is missing format", product.getId(), fileIndex);
+            @Override
+            public AviationProduct build() {
+                checkState(!getId().isEmpty(), "id is empty");
+                checkState(!getRoute().isEmpty(), "route is empty");
+                checkState(!getBuildersOfFileConfigs().isEmpty(), "fileConfigs (files) is empty");
+                return super.build();
+            }
+
+            public List<FileConfig.Builder> getFiles() {
+                return getBuildersOfFileConfigs();
+            }
+
+            public Builder setFiles(final List<FileConfig.Builder> files) {
+                return clearFileConfigs().addAllBuildersOfFileConfigs(files);
             }
         }
     }
 
-    /**
-     * Aviation product.
-     */
-    public static class AviationProduct {
-        private String id;
-        private String route;
-        private int routeId = -1;
-        private File inputDir;
-        private File archiveDir;
-        private File failDir;
-        private List<FileConfig> files = Collections.emptyList();
-
-        public AviationProduct() {
+    @FreeBuilder
+    public static abstract class FileConfig {
+        FileConfig() {
         }
 
-        public AviationProduct(final String id, final String route, final int routeId, final File inputDir, final File archiveDir, final File failDir,
-                final List<FileConfig> files) {
-            this.id = id;
-            this.route = route;
-            this.routeId = routeId;
-            this.inputDir = inputDir;
-            this.archiveDir = archiveDir;
-            this.failDir = failDir;
-            this.files = Collections.unmodifiableList(files);
-        }
+        public abstract Pattern getPattern();
 
-        public String getId() {
-            return id;
-        }
+        public abstract ZoneId getNameTimeZone();
 
-        public void setId(final String id) {
-            this.id = id;
-        }
+        public abstract GenericAviationWeatherMessage.Format getFormat();
 
-        public String getRoute() {
-            return route;
-        }
+        public abstract int getFormatId();
 
-        public void setRoute(final String route) {
-            this.route = route;
-        }
+        public static class Builder extends AviationProductsHolder_FileConfig_Builder {
+            public Builder() {
+            }
 
-        public int getRouteId() {
-            return routeId;
-        }
-
-        public void setRouteId(final int routeId) {
-            this.routeId = routeId;
-        }
-
-        public File getInputDir() {
-            return inputDir;
-        }
-
-        public void setInputDir(final File inputDir) {
-            this.inputDir = inputDir;
-        }
-
-        public File getArchiveDir() {
-            return archiveDir;
-        }
-
-        public void setArchiveDir(final File archiveDir) {
-            this.archiveDir = archiveDir;
-        }
-
-        public File getFailDir() {
-            return failDir;
-        }
-
-        public void setFailDir(final File failDir) {
-            this.failDir = failDir;
-        }
-
-        public List<FileConfig> getFiles() {
-            return Collections.unmodifiableList(files);
-        }
-
-        public void setFiles(final List<FileConfig> files) {
-            this.files = Collections.unmodifiableList(files);
-        }
-    }
-
-    public static class FileConfig {
-        private Pattern pattern;
-        private ZoneId nameTimeZone = ZoneOffset.UTC;
-        private GenericAviationWeatherMessage.Format format;
-        private int formatId = -1;
-
-        public FileConfig() {
-        }
-
-        public FileConfig(final Pattern pattern, final ZoneId nameTimeZone, final GenericAviationWeatherMessage.Format format, final int formatId) {
-            this.pattern = pattern;
-            this.nameTimeZone = nameTimeZone;
-            this.format = format;
-            this.formatId = formatId;
-        }
-
-        public Pattern getPattern() {
-            return pattern;
-        }
-
-        public void setPattern(final Pattern pattern) {
-            this.pattern = pattern;
-        }
-
-        public ZoneId getNameTimeZone() {
-            return nameTimeZone;
-        }
-
-        public void setNameTimeZone(final ZoneId nameTimeZone) {
-            this.nameTimeZone = nameTimeZone;
-        }
-
-        public GenericAviationWeatherMessage.Format getFormat() {
-            return format;
-        }
-
-        public void setFormat(final GenericAviationWeatherMessage.Format format) {
-            this.format = format;
-        }
-
-        public int getFormatId() {
-            return formatId;
-        }
-
-        public void setFormatId(final int formatId) {
-            this.formatId = formatId;
+            @Override
+            public FileConfig build() {
+                checkState(!getPattern().toString().isEmpty(), "pattern is empty");
+                return super.build();
+            }
         }
     }
 }

--- a/src/main/java/fi/fmi/avi/archiver/initializing/AviationProductsHolder.java
+++ b/src/main/java/fi/fmi/avi/archiver/initializing/AviationProductsHolder.java
@@ -5,15 +5,16 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 import org.inferred.freebuilder.FreeBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import com.google.common.collect.ImmutableMap;
 
 import fi.fmi.avi.model.GenericAviationWeatherMessage;
 
@@ -22,7 +23,7 @@ import fi.fmi.avi.model.GenericAviationWeatherMessage;
  */
 @Component
 public class AviationProductsHolder {
-    private final List<AviationProduct> products;
+    private final Map<String, AviationProduct> products;
 
     public AviationProductsHolder(@Autowired final AviationProductBuildersHolder aviationProductBuildersHolder) {
         requireNonNull(aviationProductBuildersHolder, "aviationProductBuildersHolder");
@@ -40,15 +41,22 @@ public class AviationProductsHolder {
         }
     }
 
-    private List<AviationProduct> buildProducts(final List<AviationProduct.Builder> productBuilders) {
+    private Map<String, AviationProduct> buildProducts(final List<AviationProduct.Builder> productBuilders) {
         checkState(!productBuilders.isEmpty(), "Products are missing");
-        final int size = productBuilders.size();
-        final List<AviationProduct> builder = new ArrayList<>(size);
-        iterateProducts(productBuilders, product -> builder.add(product.build()));
-        return Collections.unmodifiableList(builder);
+        final ImmutableMap.Builder<String, AviationProduct> builder = ImmutableMap.builder();
+        iterateProducts(productBuilders, productBuilder -> {
+            final AviationProduct product = productBuilder.build();
+            builder.put(product.getId(), product);
+        });
+        return builder.build();
     }
 
-    public List<AviationProduct> getProducts() {
+    /**
+     * Returns products indexed by product id (returned by {@link AviationProduct#getId()}).
+     *
+     * @return products
+     */
+    public Map<String, AviationProduct> getProducts() {
         return products;
     }
 

--- a/src/main/java/fi/fmi/avi/archiver/initializing/MessageFileMonitorInitializer.java
+++ b/src/main/java/fi/fmi/avi/archiver/initializing/MessageFileMonitorInitializer.java
@@ -70,7 +70,7 @@ public class MessageFileMonitorInitializer {
 
     @PostConstruct
     private void initializeFilePatternFlows() {
-        aviationProductsHolder.getProducts().forEach(product -> {
+        aviationProductsHolder.getProducts().values().forEach(product -> {
             final FileReadingMessageSource sourceDirectory = new FileReadingMessageSource();
             sourceDirectory.setDirectory(product.getInputDir());
 

--- a/src/main/java/fi/fmi/avi/archiver/initializing/MessageFileMonitorInitializer.java
+++ b/src/main/java/fi/fmi/avi/archiver/initializing/MessageFileMonitorInitializer.java
@@ -93,7 +93,7 @@ public class MessageFileMonitorInitializer {
             ).register());
 
             // Integration flow for file name filtering
-            product.getFiles().stream().map(fileConfig -> context.registration(IntegrationFlows.from(inputChannel)//
+            product.getFileConfigs().stream().map(fileConfig -> context.registration(IntegrationFlows.from(inputChannel)//
                             .filter(new RegexPatternFileListFilter(fileConfig.getPattern())::accept)//
                             .enrichHeaders(s -> s.header(PRODUCT_KEY, product)//
                                     .headerFunction(PRODUCT_IDENTIFIER, message -> product.getId())

--- a/src/test-integration/java/fi/fmi/avi/archiver/AviationMessageArchiverTest.java
+++ b/src/test-integration/java/fi/fmi/avi/archiver/AviationMessageArchiverTest.java
@@ -99,10 +99,8 @@ public class AviationMessageArchiverTest {
         public abstract String getProductName();
 
         public AviationProductsHolder.AviationProduct getProduct(final AviationProductsHolder holder) {
-            return holder.getProducts().stream()//
-                    .filter(aviationProduct -> aviationProduct.getId().equals(getProductName()))//
-                    .findFirst()//
-                    .orElseThrow(IllegalStateException::new);
+            final String productName = getProductName();
+            return requireNonNull(holder.getProducts().get(productName), productName);
         }
 
         public void assertInputAndOutputFilesEquals(final AviationProductsHolder.AviationProduct product) throws InterruptedException, URISyntaxException {

--- a/src/test-integration/java/fi/fmi/avi/archiver/initializing/AviationProductsHolderTest.java
+++ b/src/test-integration/java/fi/fmi/avi/archiver/initializing/AviationProductsHolderTest.java
@@ -35,8 +35,7 @@ class AviationProductsHolderTest {
 
     @Test
     public void product_routes_have_id() {
-        final Map<String, Integer> actualRouteIds = aviationProductsHolder.getProducts()
-                .stream()
+        final Map<String, Integer> actualRouteIds = aviationProductsHolder.getProducts().values().stream()//
                 .collect(Collectors.toMap(product -> product.getId() + ":" + product.getRoute(), AviationProductsHolder.AviationProduct::getRouteId));
         assertThat(actualRouteIds)//
                 .isNotEmpty()//
@@ -45,9 +44,8 @@ class AviationProductsHolderTest {
 
     @Test
     public void product_routes_have_id_equal_to_route_table() {
-        final List<Map.Entry<String, Integer>> actualRouteIds = aviationProductsHolder.getProducts()
-                .stream()
-                .map(product -> new SimpleImmutableEntry<>(product.getRoute(), product.getRouteId()))
+        final List<Map.Entry<String, Integer>> actualRouteIds = aviationProductsHolder.getProducts().values().stream()//
+                .map(product -> new SimpleImmutableEntry<>(product.getRoute(), product.getRouteId()))//
                 .collect(Collectors.toList());
         assertThat(actualRouteIds)//
                 .isNotEmpty()//
@@ -56,7 +54,7 @@ class AviationProductsHolderTest {
 
     @Test
     public void product_file_message_formats_have_id() {
-        final List<Map.Entry<String, Integer>> actualFormatIds = aviationProductsHolder.getProducts().stream()//
+        final List<Map.Entry<String, Integer>> actualFormatIds = aviationProductsHolder.getProducts().values().stream()//
                 .flatMap(product -> product.getFileConfigs()
                         .stream()
                         .map(file -> new SimpleImmutableEntry<>(product.getId() + ":" + file.getFormat(), file.getFormatId())))//
@@ -68,7 +66,7 @@ class AviationProductsHolderTest {
 
     @Test
     public void product_file_message_formats_have_id_equal_to_format_table() {
-        final List<Map.Entry<GenericAviationWeatherMessage.Format, Integer>> actualFormatIds = aviationProductsHolder.getProducts().stream()//
+        final List<Map.Entry<GenericAviationWeatherMessage.Format, Integer>> actualFormatIds = aviationProductsHolder.getProducts().values().stream()//
                 .flatMap(product -> product.getFileConfigs().stream().map(file -> new SimpleImmutableEntry<>(file.getFormat(), file.getFormatId())))//
                 .collect(Collectors.toList());
         assertThat(actualFormatIds)//

--- a/src/test-integration/java/fi/fmi/avi/archiver/initializing/AviationProductsHolderTest.java
+++ b/src/test-integration/java/fi/fmi/avi/archiver/initializing/AviationProductsHolderTest.java
@@ -57,7 +57,7 @@ class AviationProductsHolderTest {
     @Test
     public void product_file_message_formats_have_id() {
         final List<Map.Entry<String, Integer>> actualFormatIds = aviationProductsHolder.getProducts().stream()//
-                .flatMap(product -> product.getFiles()
+                .flatMap(product -> product.getFileConfigs()
                         .stream()
                         .map(file -> new SimpleImmutableEntry<>(product.getId() + ":" + file.getFormat(), file.getFormatId())))//
                 .collect(Collectors.toList());
@@ -69,7 +69,7 @@ class AviationProductsHolderTest {
     @Test
     public void product_file_message_formats_have_id_equal_to_format_table() {
         final List<Map.Entry<GenericAviationWeatherMessage.Format, Integer>> actualFormatIds = aviationProductsHolder.getProducts().stream()//
-                .flatMap(product -> product.getFiles().stream().map(file -> new SimpleImmutableEntry<>(file.getFormat(), file.getFormatId())))//
+                .flatMap(product -> product.getFileConfigs().stream().map(file -> new SimpleImmutableEntry<>(file.getFormat(), file.getFormatId())))//
                 .collect(Collectors.toList());
         assertThat(actualFormatIds)//
                 .isNotEmpty()//

--- a/src/test-integration/java/fi/fmi/avi/archiver/populator/FailingPopulatorTest.java
+++ b/src/test-integration/java/fi/fmi/avi/archiver/populator/FailingPopulatorTest.java
@@ -101,10 +101,7 @@ public class FailingPopulatorTest {
     }
 
     public AviationProductsHolder.AviationProduct getProduct(final AviationProductsHolder holder) {
-        return holder.getProducts().stream()//
-                .filter(aviationProduct -> aviationProduct.getId().equals(PRODUCT))//
-                .findFirst()//
-                .orElseThrow(IllegalStateException::new);
+        return requireNonNull(holder.getProducts().get(PRODUCT), PRODUCT);
     }
 
     private void waitUntilFileExists(final File expectedOutputFile) throws InterruptedException {


### PR DESCRIPTION
This pull request provides an immutable product config API. It is implemented using FreeBuilder classes. Spring boot populates the builders into `AviationProductBuildersHolder`, and then builds the builders on construction of `AviationProductsHolder`.

Benefits of this solution:
* Less code, as FreeBuilder automates a lot
* Presence of mandatory values is automatically checked upon build - no need for manual and error-prone checking.
* Value content checks are convenient to do in `build()` method.

Downsides of this solution:
* Care must be taken with collection properties. One must provide a setters and getters for collections of builders in the builder class.

Closes #28.
