### PR TITLE
Set FileReadingMessageSource's flow auto start-up to false

### DIFF
--- a/src/main/java/fi/fmi/avi/archiver/initializing/MessageFileMonitorInitializer.java
+++ b/src/main/java/fi/fmi/avi/archiver/initializing/MessageFileMonitorInitializer.java
@@ -108,9 +108,10 @@ public class MessageFileMonitorInitializer {
 
             // Initialize source directory polling. Uses poller bean
             registerations.add(context.registration(IntegrationFlows.from(sourceDirectory)//
-                    .channel(inputChannel)//
-                    .get()//
-            ).register());
+                            .channel(inputChannel)//
+                            .get())
+                    .autoStartup(false)
+                    .register());
 
             // Integration flow for file name filtering
             product.getFileConfigs().stream().map(fileConfig -> context.registration(IntegrationFlows.from(inputChannel)//


### PR DESCRIPTION
...to ensure it starts after the whole integration context has been constructed.