### PR TITLE
SDM-2666: Parse observationTime into InputAviationMessage

### DIFF
--- a/src/main/java/fi/fmi/avi/archiver/file/InputAviationMessage.java
+++ b/src/main/java/fi/fmi/avi/archiver/file/InputAviationMessage.java
@@ -4,7 +4,7 @@ import fi.fmi.avi.archiver.message.MessagePositionInFile;
 import fi.fmi.avi.model.GenericAviationWeatherMessage;
 import org.inferred.freebuilder.FreeBuilder;
 
-import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.Optional;
 
 /**
@@ -39,7 +39,7 @@ public abstract class InputAviationMessage {
      *
      * @return observation time or empty if not available
      */
-    public abstract Optional<Instant> getIwxxmObservationTime();
+    public abstract Optional<OffsetDateTime> getIwxxmObservationTime();
 
     /**
      * Return metadata of the file this message belongs to.

--- a/src/main/java/fi/fmi/avi/archiver/file/InputAviationMessage.java
+++ b/src/main/java/fi/fmi/avi/archiver/file/InputAviationMessage.java
@@ -1,9 +1,11 @@
 package fi.fmi.avi.archiver.file;
 
-import org.inferred.freebuilder.FreeBuilder;
-
 import fi.fmi.avi.archiver.message.MessagePositionInFile;
 import fi.fmi.avi.model.GenericAviationWeatherMessage;
+import org.inferred.freebuilder.FreeBuilder;
+
+import java.time.Instant;
+import java.util.Optional;
 
 /**
  * Model representing content and metadata parsed from a file per message.
@@ -31,6 +33,13 @@ public abstract class InputAviationMessage {
      * @return COLLECT document identifier
      */
     public abstract InputBulletinHeading getCollectIdentifier();
+
+    /**
+     * METAR/SPECI specific observation time parsed from IWXXM, if available.
+     *
+     * @return observation time or empty if not available
+     */
+    public abstract Optional<Instant> getIwxxmObservationTime();
 
     /**
      * Return metadata of the file this message belongs to.

--- a/src/test/java/fi/fmi/avi/archiver/file/FileParserTest.java
+++ b/src/test/java/fi/fmi/avi/archiver/file/FileParserTest.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -371,7 +372,7 @@ public class FileParserTest {
         assertThat(result).hasSize(1);
 
         final InputAviationMessage msg = result.getFirst();
-        assertThat(msg.getIwxxmObservationTime()).contains(Instant.parse("2012-08-22T16:30:00Z"));
+        assertThat(msg.getIwxxmObservationTime()).contains(OffsetDateTime.parse("2012-08-22T16:30:00Z"));
     }
 
     @Test
@@ -388,7 +389,7 @@ public class FileParserTest {
         assertThat(result).hasSize(1);
 
         final InputAviationMessage msg = result.getFirst();
-        assertThat(msg.getIwxxmObservationTime()).contains(Instant.parse("2025-09-04T10:15:00Z"));
+        assertThat(msg.getIwxxmObservationTime()).contains(OffsetDateTime.parse("2025-09-04T10:15:00Z"));
     }
 
     @Test
@@ -422,7 +423,7 @@ public class FileParserTest {
         assertThat(result).hasSize(1);
 
         final InputAviationMessage msg = result.getFirst();
-        assertThat(msg.getIwxxmObservationTime()).contains(Instant.parse("2025-09-04T12:34:56Z"));
+        assertThat(msg.getIwxxmObservationTime()).contains(OffsetDateTime.parse("2025-09-04T12:34:56Z"));
     }
 
     @Test
@@ -441,9 +442,9 @@ public class FileParserTest {
         assertThat(result)
                 .extracting(message -> message.getIwxxmObservationTime().orElse(null))
                 .containsExactlyInAnyOrder(
-                        Instant.parse("2025-09-04T10:00:00Z"),
-                        Instant.parse("2025-09-04T10:30:00Z"),
-                        Instant.parse("2025-09-04T11:00:00Z")
+                        OffsetDateTime.parse("2025-09-04T10:00:00Z"),
+                        OffsetDateTime.parse("2025-09-04T10:30:00Z"),
+                        OffsetDateTime.parse("2025-09-04T11:00:00Z")
                 );
     }
 
@@ -471,8 +472,8 @@ public class FileParserTest {
                 .filter(m -> m.getMessage().getMessageType().orElse(null) == MessageType.TAF)
                 .findFirst().orElseThrow();
 
-        assertThat(metar.getIwxxmObservationTime()).contains(Instant.parse("2025-09-04T15:00:00Z"));
-        assertThat(speci.getIwxxmObservationTime()).contains(Instant.parse("2025-09-04T15:20:00Z"));
+        assertThat(metar.getIwxxmObservationTime()).contains(OffsetDateTime.parse("2025-09-04T15:00:00Z"));
+        assertThat(speci.getIwxxmObservationTime()).contains(OffsetDateTime.parse("2025-09-04T15:20:00Z"));
         assertThat(taf.getIwxxmObservationTime()).isEmpty();
     }
 

--- a/src/test/java/fi/fmi/avi/archiver/file/FileParserTest.java
+++ b/src/test/java/fi/fmi/avi/archiver/file/FileParserTest.java
@@ -356,4 +356,124 @@ public class FileParserTest {
         assertThat(result).isEmpty();
         assertThat(processingServiceContext.isProcessingErrors()).isTrue();
     }
+
+    @Test
+    void metar_iwxxm_2025_2_observation_time() {
+        final String filename = "metar-iwxxm-2025-2.xml";
+        final FileMetadata metadata = DEFAULT_METADATA.toBuilder()
+                .mutateFileReference(ref -> ref.setFilename(filename))
+                .setFileConfig(IWXXM_FILECONFIG)
+                .build();
+
+        final List<InputAviationMessage> result = fileParser.parse(getFileContent(filename), metadata, processingServiceContext);
+
+        assertThat(processingServiceContext.isProcessingErrors()).isFalse();
+        assertThat(result).hasSize(1);
+
+        final InputAviationMessage msg = result.getFirst();
+        assertThat(msg.getIwxxmObservationTime()).contains(Instant.parse("2012-08-22T16:30:00Z"));
+    }
+
+    @Test
+    void metar_iwxxm_observation_time() {
+        final String filename = "metar-observationTime.xml";
+        final FileMetadata metadata = DEFAULT_METADATA.toBuilder()
+                .mutateFileReference(ref -> ref.setFilename(filename))
+                .setFileConfig(IWXXM_FILECONFIG)
+                .build();
+
+        final List<InputAviationMessage> result = fileParser.parse(getFileContent(filename), metadata, processingServiceContext);
+
+        assertThat(processingServiceContext.isProcessingErrors()).isFalse();
+        assertThat(result).hasSize(1);
+
+        final InputAviationMessage msg = result.getFirst();
+        assertThat(msg.getIwxxmObservationTime()).contains(Instant.parse("2025-09-04T10:15:00Z"));
+    }
+
+    @Test
+    void metar_iwxxm_observation_time_invalid() {
+        final String filename = "metar-observationTime-invalid.xml";
+        final FileMetadata metadata = DEFAULT_METADATA.toBuilder()
+                .mutateFileReference(ref -> ref.setFilename(filename))
+                .setFileConfig(IWXXM_FILECONFIG)
+                .build();
+
+        final List<InputAviationMessage> result = fileParser.parse(getFileContent(filename), metadata, processingServiceContext);
+
+        assertThat(processingServiceContext.isProcessingErrors()).isFalse();
+        assertThat(result).hasSize(1);
+
+        final InputAviationMessage msg = result.getFirst();
+        assertThat(msg.getIwxxmObservationTime()).isEmpty();
+    }
+
+    @Test
+    void speci_iwxxm_observation_time() {
+        final String filename = "speci-observationTime.xml";
+        final FileMetadata metadata = DEFAULT_METADATA.toBuilder()
+                .mutateFileReference(ref -> ref.setFilename(filename))
+                .setFileConfig(IWXXM_FILECONFIG)
+                .build();
+
+        final List<InputAviationMessage> result = fileParser.parse(getFileContent(filename), metadata, processingServiceContext);
+
+        assertThat(processingServiceContext.isProcessingErrors()).isFalse();
+        assertThat(result).hasSize(1);
+
+        final InputAviationMessage msg = result.getFirst();
+        assertThat(msg.getIwxxmObservationTime()).contains(Instant.parse("2025-09-04T12:34:56Z"));
+    }
+
+    @Test
+    void metar_iwxxm_collect_three_metars_extracts_observation_times() {
+        final String filename = "metar-collect-3.xml";
+        final FileMetadata metadata = DEFAULT_METADATA.toBuilder()
+                .mutateFileReference(ref -> ref.setFilename(filename))
+                .setFileConfig(IWXXM_FILECONFIG)
+                .build();
+
+        final List<InputAviationMessage> result =
+                fileParser.parse(getFileContent(filename), metadata, processingServiceContext);
+
+        assertThat(processingServiceContext.isProcessingErrors()).isFalse();
+        assertThat(result).hasSize(3);
+        assertThat(result)
+                .extracting(message -> message.getIwxxmObservationTime().orElse(null))
+                .containsExactlyInAnyOrder(
+                        Instant.parse("2025-09-04T10:00:00Z"),
+                        Instant.parse("2025-09-04T10:30:00Z"),
+                        Instant.parse("2025-09-04T11:00:00Z")
+                );
+    }
+
+    @Test
+    void collect_with__metar_speci_and_taf_sets_observation_time_for_metar_and_speci_only() {
+        final String filename = "collect-metar-speci-taf.xml";
+        final FileMetadata metadata = DEFAULT_METADATA.toBuilder()
+                .mutateFileReference(ref -> ref.setFilename(filename))
+                .setFileConfig(IWXXM_FILECONFIG)
+                .build();
+
+        final List<InputAviationMessage> result =
+                fileParser.parse(getFileContent(filename), metadata, processingServiceContext);
+
+        assertThat(processingServiceContext.isProcessingErrors()).isFalse();
+        assertThat(result).hasSize(3);
+
+        final InputAviationMessage metar = result.stream()
+                .filter(m -> m.getMessage().getMessageType().orElse(null) == MessageType.METAR)
+                .findFirst().orElseThrow();
+        final InputAviationMessage speci = result.stream()
+                .filter(m -> m.getMessage().getMessageType().orElse(null) == MessageType.SPECI)
+                .findFirst().orElseThrow();
+        final InputAviationMessage taf = result.stream()
+                .filter(m -> m.getMessage().getMessageType().orElse(null) == MessageType.TAF)
+                .findFirst().orElseThrow();
+
+        assertThat(metar.getIwxxmObservationTime()).contains(Instant.parse("2025-09-04T15:00:00Z"));
+        assertThat(speci.getIwxxmObservationTime()).contains(Instant.parse("2025-09-04T15:20:00Z"));
+        assertThat(taf.getIwxxmObservationTime()).isEmpty();
+    }
+
 }

--- a/src/test/resources/fi/fmi/avi/archiver/file/collect-metar-speci-taf.xml
+++ b/src/test/resources/fi/fmi/avi/archiver/file/collect-metar-speci-taf.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collect:MeteorologicalBulletin
+  xmlns:collect="http://def.wmo.int/collect/2014"
+  xmlns:gml="http://www.opengis.net/gml/3.2"
+  xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
+  xmlns:iwxxm="http://icao.int/iwxxm/3.0"
+  xmlns:metce="http://def.wmo.int/metce/2013"
+  xmlns:om="http://www.opengis.net/om/2.0"
+  xmlns:sam="http://www.opengis.net/sampling/2.0"
+  xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  gml:id="bulletin-metar-speci-taf-proper"
+  xsi:schemaLocation="
+        http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0/iwxxm.xsd
+        http://def.wmo.int/collect/2014 http://schemas.wmo.int/collect/1.2/collect.xsd
+        http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd">
+  <collect:meteorologicalInformation>
+    <iwxxm:METAR gml:id="metar-efaa-1"
+                 reportStatus="NORMAL"
+                 permissibleUsage="OPERATIONAL"
+                 automatedStation="true">
+      <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="issue-efaa-1">
+          <gml:timePosition>2025-09-04T15:01:00Z</gml:timePosition>
+        </gml:TimeInstant>
+      </iwxxm:issueTime>
+      <iwxxm:observationTime>
+        <gml:TimeInstant gml:id="obs-efaa-1">
+          <gml:timePosition>2025-09-04T15:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+      </iwxxm:observationTime>
+      <iwxxm:aerodrome>
+        <aixm:AirportHeliport gml:id="ad-efaa">
+          <aixm:timeSlice>
+            <aixm:AirportHeliportTimeSlice gml:id="adts-efaa">
+              <gml:validTime/>
+              <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+              <aixm:designator>EFAA</aixm:designator>
+              <aixm:name>EXAMPLE AERODROME A</aixm:name>
+              <aixm:locationIndicatorICAO>EFAA</aixm:locationIndicatorICAO>
+            </aixm:AirportHeliportTimeSlice>
+          </aixm:timeSlice>
+        </aixm:AirportHeliport>
+      </iwxxm:aerodrome>
+    </iwxxm:METAR>
+
+    <iwxxm:SPECI gml:id="speci-efcc-1"
+                 reportStatus="NORMAL"
+                 permissibleUsage="OPERATIONAL"
+                 automatedStation="true">
+      <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="issue-efcc-1">
+          <gml:timePosition>2025-09-04T15:21:00Z</gml:timePosition>
+        </gml:TimeInstant>
+      </iwxxm:issueTime>
+      <iwxxm:observationTime>
+        <gml:TimeInstant gml:id="obs-efcc-1">
+          <gml:timePosition>2025-09-04T15:20:00Z</gml:timePosition>
+        </gml:TimeInstant>
+      </iwxxm:observationTime>
+      <iwxxm:aerodrome>
+        <aixm:AirportHeliport gml:id="ad-efcc">
+          <aixm:timeSlice>
+            <aixm:AirportHeliportTimeSlice gml:id="adts-efcc">
+              <gml:validTime/>
+              <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+              <aixm:designator>EFCC</aixm:designator>
+              <aixm:name>EXAMPLE AERODROME C</aixm:name>
+              <aixm:locationIndicatorICAO>EFCC</aixm:locationIndicatorICAO>
+            </aixm:AirportHeliportTimeSlice>
+          </aixm:timeSlice>
+        </aixm:AirportHeliport>
+      </iwxxm:aerodrome>
+    </iwxxm:SPECI>
+
+    <iwxxm:TAF gml:id="taf-efbb-1"
+               permissibleUsage="OPERATIONAL"
+               status="NORMAL">
+      <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="taf-issue-efbb-1">
+          <gml:timePosition>2025-09-04T12:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+      </iwxxm:issueTime>
+      <iwxxm:validTime>
+        <gml:TimePeriod gml:id="taf-valid-efbb-1">
+          <gml:beginPosition>2025-09-04T12:00:00Z</gml:beginPosition>
+          <gml:endPosition>2025-09-05T12:00:00Z</gml:endPosition>
+        </gml:TimePeriod>
+      </iwxxm:validTime>
+      <iwxxm:aerodrome>
+        <aixm:AirportHeliport gml:id="ad-efbb">
+          <aixm:timeSlice>
+            <aixm:AirportHeliportTimeSlice gml:id="adts-efbb">
+              <gml:validTime/>
+              <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+              <aixm:designator>EFBB</aixm:designator>
+              <aixm:name>EXAMPLE AERODROME B</aixm:name>
+              <aixm:locationIndicatorICAO>EFBB</aixm:locationIndicatorICAO>
+            </aixm:AirportHeliportTimeSlice>
+          </aixm:timeSlice>
+        </aixm:AirportHeliport>
+      </iwxxm:aerodrome>
+      <iwxxm:baseForecast>
+        <om:OM_Observation gml:id="bfct-efbb-1">
+          <om:type xlink:href="http://codes.wmo.int/49-2/observation-type/iwxxm/3.0/MeteorologicalAerodromeForecast"
+                   xlink:title="Aerodrome Base Forecast"/>
+          <om:phenomenonTime xlink:href="#taf-valid-efbb-1"/>
+          <om:resultTime xlink:href="#taf-issue-efbb-1"/>
+          <om:validTime xlink:href="#taf-valid-efbb-1"/>
+          <om:procedure>
+            <metce:Process gml:id="proc-taf-efbb-1">
+              <gml:description>WMO No. 49-2 TAF generation</gml:description>
+            </metce:Process>
+          </om:procedure>
+          <om:observedProperty
+            xlink:href="http://codes.wmo.int/49-2/observable-property/MeteorologicalAerodromeForecast"/>
+          <om:featureOfInterest>
+            <sams:SF_SpatialSamplingFeature gml:id="foi-efbb-1">
+              <sam:type xlink:href="http://www.opengis.net/def/samplingFeatureType/OGC-OM/2.0/SF_SamplingPoint"/>
+              <sam:sampledFeature>
+                <aixm:AirportHeliport gml:id="foi-ad-efbb">
+                  <aixm:timeSlice>
+                    <aixm:AirportHeliportTimeSlice gml:id="foi-adts-efbb">
+                      <gml:validTime/>
+                      <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                      <aixm:designator>EFBB</aixm:designator>
+                      <aixm:name>EXAMPLE AERODROME</aixm:name>
+                      <aixm:locationIndicatorICAO>EFBB</aixm:locationIndicatorICAO>
+                    </aixm:AirportHeliportTimeSlice>
+                  </aixm:timeSlice>
+                </aixm:AirportHeliport>
+              </sam:sampledFeature>
+              <sams:shape>
+                <gml:Point gml:id="foi-point-efbb"
+                           srsName="http://www.opengis.net/def/crs/EPSG/0/4326"
+                           srsDimension="2">
+                  <gml:pos>24.0 60.0</gml:pos>
+                </gml:Point>
+              </sams:shape>
+            </sams:SF_SpatialSamplingFeature>
+          </om:featureOfInterest>
+          <om:result>
+            <iwxxm:MeteorologicalAerodromeForecastRecord gml:id="taf-rec-efbb-1" cloudAndVisibilityOK="true"/>
+          </om:result>
+        </om:OM_Observation>
+      </iwxxm:baseForecast>
+    </iwxxm:TAF>
+  </collect:meteorologicalInformation>
+
+  <collect:bulletinIdentifier>A_LTFI31EFKL301115_C_EFKL_201902011315--.xml</collect:bulletinIdentifier>
+</collect:MeteorologicalBulletin>

--- a/src/test/resources/fi/fmi/avi/archiver/file/metar-collect-3.xml
+++ b/src/test/resources/fi/fmi/avi/archiver/file/metar-collect-3.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collect:MeteorologicalBulletin
+  xmlns:collect="http://def.wmo.int/collect/2014"
+  xmlns:gml="http://www.opengis.net/gml/3.2"
+  xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
+  xmlns:iwxxm="http://icao.int/iwxxm/3.0"
+  xmlns:metce="http://def.wmo.int/metce/2013"
+  xmlns:om="http://www.opengis.net/om/2.0"
+  xmlns:sam="http://www.opengis.net/sampling/2.0"
+  xmlns:sams="http://www.opengis.net/samplingSpatial/2.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  gml:id="bulletin-4d9a9a0a-7a7c-4c1a-9e5a-1234567890ab"
+  xsi:schemaLocation="
+        http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0/iwxxm.xsd
+        http://def.wmo.int/collect/2014 http://schemas.wmo.int/collect/1.2/collect.xsd
+        http://www.opengis.net/samplingSpatial/2.0 http://schemas.opengis.net/samplingSpatial/2.0/spatialSamplingFeature.xsd">
+  <collect:meteorologicalInformation>
+    <iwxxm:METAR gml:id="metar-efhk-1"
+                 reportStatus="NORMAL"
+                 permissibleUsage="NON-OPERATIONAL"
+                 permissibleUsageReason="TEST"
+                 automatedStation="true">
+      <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="issue-efhk-1">
+          <gml:timePosition>2025-09-04T10:01:00Z</gml:timePosition>
+        </gml:TimeInstant>
+      </iwxxm:issueTime>
+      <iwxxm:observationTime>
+        <gml:TimeInstant gml:id="obs-efhk-1">
+          <gml:timePosition>2025-09-04T10:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+      </iwxxm:observationTime>
+      <iwxxm:aerodrome>
+        <aixm:AirportHeliport gml:id="ad-efhk">
+          <aixm:timeSlice>
+            <aixm:AirportHeliportTimeSlice gml:id="adts-efhk">
+              <gml:validTime/>
+              <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+              <aixm:designator>EFHK</aixm:designator>
+              <aixm:name>HELSINKI-VANTAA</aixm:name>
+              <aixm:locationIndicatorICAO>EFHK</aixm:locationIndicatorICAO>
+            </aixm:AirportHeliportTimeSlice>
+          </aixm:timeSlice>
+        </aixm:AirportHeliport>
+      </iwxxm:aerodrome>
+    </iwxxm:METAR>
+  </collect:meteorologicalInformation>
+
+  <collect:meteorologicalInformation>
+    <iwxxm:METAR gml:id="metar-eftu-1"
+                 reportStatus="NORMAL"
+                 permissibleUsage="NON-OPERATIONAL"
+                 permissibleUsageReason="TEST"
+                 automatedStation="true">
+      <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="issue-eftu-1">
+          <gml:timePosition>2025-09-04T10:31:00Z</gml:timePosition>
+        </gml:TimeInstant>
+      </iwxxm:issueTime>
+      <iwxxm:observationTime>
+        <gml:TimeInstant gml:id="obs-eftu-1">
+          <gml:timePosition>2025-09-04T10:30:00Z</gml:timePosition>
+        </gml:TimeInstant>
+      </iwxxm:observationTime>
+      <iwxxm:aerodrome>
+        <aixm:AirportHeliport gml:id="ad-eftu">
+          <aixm:timeSlice>
+            <aixm:AirportHeliportTimeSlice gml:id="adts-eftu">
+              <gml:validTime/>
+              <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+              <aixm:designator>EFTU</aixm:designator>
+              <aixm:name>TURKU AIRPORT</aixm:name>
+              <aixm:locationIndicatorICAO>EFTU</aixm:locationIndicatorICAO>
+            </aixm:AirportHeliportTimeSlice>
+          </aixm:timeSlice>
+        </aixm:AirportHeliport>
+      </iwxxm:aerodrome>
+    </iwxxm:METAR>
+  </collect:meteorologicalInformation>
+
+  <collect:meteorologicalInformation>
+    <iwxxm:METAR gml:id="metar-efet-1"
+                 reportStatus="NORMAL"
+                 permissibleUsage="NON-OPERATIONAL"
+                 permissibleUsageReason="TEST"
+                 automatedStation="true">
+      <iwxxm:issueTime>
+        <gml:TimeInstant gml:id="issue-efet-1">
+          <gml:timePosition>2025-09-04T11:01:00Z</gml:timePosition>
+        </gml:TimeInstant>
+      </iwxxm:issueTime>
+      <iwxxm:observationTime>
+        <gml:TimeInstant gml:id="obs-efet-1">
+          <gml:timePosition>2025-09-04T11:00:00Z</gml:timePosition>
+        </gml:TimeInstant>
+      </iwxxm:observationTime>
+      <iwxxm:aerodrome>
+        <aixm:AirportHeliport gml:id="ad-efet">
+          <aixm:timeSlice>
+            <aixm:AirportHeliportTimeSlice gml:id="adts-efet">
+              <gml:validTime/>
+              <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+              <aixm:designator>EFET</aixm:designator>
+              <aixm:name>ENONTEKIÖ AIRPORT</aixm:name>
+              <aixm:locationIndicatorICAO>EFET</aixm:locationIndicatorICAO>
+            </aixm:AirportHeliportTimeSlice>
+          </aixm:timeSlice>
+        </aixm:AirportHeliport>
+      </iwxxm:aerodrome>
+    </iwxxm:METAR>
+  </collect:meteorologicalInformation>
+
+  <collect:bulletinIdentifier>A_LTFI31EFKL301115_C_EFKL_201902011315--.xml</collect:bulletinIdentifier>
+</collect:MeteorologicalBulletin>

--- a/src/test/resources/fi/fmi/avi/archiver/file/metar-iwxxm-2025-2.xml
+++ b/src/test/resources/fi/fmi/avi/archiver/file/metar-iwxxm-2025-2.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iwxxm:METAR
+  xmlns:iwxxm="http://icao.int/iwxxm/2025-2"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:gml="http://www.opengis.net/gml/3.2"
+  xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://icao.int/iwxxm/2025-2 http://schemas.wmo.int/iwxxm/2025-2RC1/iwxxm.xsd"
+  gml:id="uuid.510df5de-fefb-4406-bafd-faab35333ec0"
+  reportStatus="NORMAL"
+  permissibleUsage="OPERATIONAL"
+  automatedStation="false">
+
+  <iwxxm:issueTime>
+    <gml:TimeInstant gml:id="uuid.e5460ae4-98a4-48fa-bbfc-21799896f1f2">
+      <gml:timePosition>2012-08-22T16:30:00Z</gml:timePosition>
+    </gml:TimeInstant>
+  </iwxxm:issueTime>
+
+  <iwxxm:aerodrome>
+    <aixm:AirportHeliport gml:id="uuid.143d63d9-15f5-442e-9bdc-1f3db93fb619">
+      <aixm:timeSlice>
+        <aixm:AirportHeliportTimeSlice gml:id="uuid.75c3340c-3679-4e31-8aec-efdabe375d49">
+          <gml:validTime/>
+          <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+          <aixm:designator>YUDO</aixm:designator>
+          <aixm:name>DONLON/INTERNATIONAL</aixm:name>
+          <aixm:locationIndicatorICAO>YUDO</aixm:locationIndicatorICAO>
+          <aixm:ARP>
+            <aixm:ElevatedPoint gml:id="uuid.dd2c810b-edaa-4ad9-bb65-9ab774d1522e" srsDimension="2" axisLabels="Lat Long" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+              <gml:pos>12.34 -12.34</gml:pos>
+              <aixm:elevation uom="M">12</aixm:elevation>
+              <aixm:verticalDatum>EGM_96</aixm:verticalDatum>
+            </aixm:ElevatedPoint>
+          </aixm:ARP>
+        </aixm:AirportHeliportTimeSlice>
+      </aixm:timeSlice>
+    </aixm:AirportHeliport>
+  </iwxxm:aerodrome>
+
+  <iwxxm:observationTime>
+    <gml:TimeInstant gml:id="uuid.85802aab-b4e5-4c4b-9303-10a02064e243">
+      <gml:timePosition>2012-08-22T16:30:00Z</gml:timePosition>
+    </gml:TimeInstant>
+  </iwxxm:observationTime>
+
+  <iwxxm:observation>
+    <iwxxm:MeteorologicalAerodromeObservation gml:id="uuid.dc262f4d-1dc8-428b-91d8-74e10ed3cf69" cloudAndVisibilityOK="false">
+      <iwxxm:airTemperature uom="Cel">17.0</iwxxm:airTemperature>
+      <iwxxm:dewpointTemperature uom="Cel">16.0</iwxxm:dewpointTemperature>
+      <iwxxm:qnh uom="hPa">1018</iwxxm:qnh>
+      <iwxxm:surfaceWind>
+        <iwxxm:AerodromeSurfaceWind variableWindDirection="false">
+          <iwxxm:meanWindDirection uom="deg">240</iwxxm:meanWindDirection>
+          <iwxxm:meanWindSpeed uom="m/s">4.0</iwxxm:meanWindSpeed>
+        </iwxxm:AerodromeSurfaceWind>
+      </iwxxm:surfaceWind>
+      <iwxxm:visibility>
+        <iwxxm:AerodromeHorizontalVisibility>
+          <iwxxm:prevailingVisibility uom="m">600</iwxxm:prevailingVisibility>
+        </iwxxm:AerodromeHorizontalVisibility>
+      </iwxxm:visibility>
+      <iwxxm:rvr>
+        <iwxxm:AerodromeRunwayVisualRange pastTendency="UPWARD">
+          <iwxxm:runway>
+            <aixm:RunwayDirection gml:id="uuid.f920a641-0eba-4fa3-9411-5c50444a0aa3">
+              <aixm:timeSlice>
+                <aixm:RunwayDirectionTimeSlice gml:id="uuid.23b637cb-c450-4a24-83dd-ec6b965fe71d">
+                  <gml:validTime/>
+                  <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+                  <aixm:designator>12</aixm:designator>
+                </aixm:RunwayDirectionTimeSlice>
+              </aixm:timeSlice>
+            </aixm:RunwayDirection>
+          </iwxxm:runway>
+          <iwxxm:meanRVR uom="m">1000</iwxxm:meanRVR>
+        </iwxxm:AerodromeRunwayVisualRange>
+      </iwxxm:rvr>
+      <iwxxm:presentWeather xlink:href="http://codes.wmo.int/306/4678/DZ"/>
+      <iwxxm:presentWeather xlink:href="http://codes.wmo.int/306/4678/FG"/>
+      <iwxxm:cloud>
+        <iwxxm:AerodromeCloud>
+          <iwxxm:layer>
+            <iwxxm:CloudLayer>
+              <iwxxm:amount xlink:href="http://codes.wmo.int/49-2/CloudAmountReportedAtAerodrome/SCT"/>
+              <iwxxm:base uom="[ft_i]">1000</iwxxm:base>
+            </iwxxm:CloudLayer>
+          </iwxxm:layer>
+          <iwxxm:layer>
+            <iwxxm:CloudLayer>
+              <iwxxm:amount xlink:href="http://codes.wmo.int/49-2/CloudAmountReportedAtAerodrome/OVC"/>
+              <iwxxm:base uom="[ft_i]">2000</iwxxm:base>
+            </iwxxm:CloudLayer>
+          </iwxxm:layer>
+        </iwxxm:AerodromeCloud>
+      </iwxxm:cloud>
+    </iwxxm:MeteorologicalAerodromeObservation>
+  </iwxxm:observation>
+
+  <iwxxm:trendForecast>
+    <iwxxm:MeteorologicalAerodromeTrendForecast gml:id="uuid.46584004-93bf-4638-a8be-86a61bc85e0f" changeIndicator="BECOMING">
+      <iwxxm:phenomenonTime>
+        <gml:TimePeriod gml:id="uuid.819b0c7a-133f-4029-b1d9-451be77e3c5f">
+          <gml:beginPosition>2012-08-22T16:30:00Z</gml:beginPosition>
+          <gml:endPosition>2012-08-22T17:00:00Z</gml:endPosition>
+        </gml:TimePeriod>
+      </iwxxm:phenomenonTime>
+      <iwxxm:timeIndicator>UNTIL</iwxxm:timeIndicator>
+      <iwxxm:prevailingVisibility uom="m">800</iwxxm:prevailingVisibility>
+      <iwxxm:weather xlink:href="http://codes.wmo.int/306/4678/FG"/>
+    </iwxxm:MeteorologicalAerodromeTrendForecast>
+  </iwxxm:trendForecast>
+
+  <iwxxm:trendForecast>
+    <iwxxm:MeteorologicalAerodromeTrendForecast gml:id="uuid.be66f283-6aae-4a84-bc84-3831c9b2e7ef" changeIndicator="BECOMING">
+      <iwxxm:phenomenonTime>
+        <gml:TimePeriod gml:id="uuid.d4d26581-aea9-4caf-abb3-0304faac191b">
+          <gml:beginPosition>2012-08-22T18:00:00Z</gml:beginPosition>
+          <gml:endPosition>2012-08-22T18:00:00Z</gml:endPosition>
+        </gml:TimePeriod>
+      </iwxxm:phenomenonTime>
+      <iwxxm:timeIndicator>AT</iwxxm:timeIndicator>
+      <iwxxm:prevailingVisibility uom="m">10000</iwxxm:prevailingVisibility>
+      <iwxxm:prevailingVisibilityOperator>ABOVE</iwxxm:prevailingVisibilityOperator>
+      <iwxxm:weather nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance"/>
+    </iwxxm:MeteorologicalAerodromeTrendForecast>
+  </iwxxm:trendForecast>
+
+</iwxxm:METAR>

--- a/src/test/resources/fi/fmi/avi/archiver/file/metar-observationTime-invalid.xml
+++ b/src/test/resources/fi/fmi/avi/archiver/file/metar-observationTime-invalid.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iwxxm:METAR
+  xmlns:iwxxm="http://icao.int/iwxxm/3.0"
+  xmlns:gml="http://www.opengis.net/gml/3.2"
+  xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:metce="http://def.wmo.int/metce/2013"
+  gml:id="metar-1"
+  reportStatus="NORMAL"
+  automatedStation="true"
+  permissibleUsage="OPERATIONAL">
+
+  <iwxxm:observationTime>
+    <gml:TimeInstant gml:id="ti-1">
+      <gml:timePosition>test</gml:timePosition>
+    </gml:TimeInstant>
+  </iwxxm:observationTime>
+
+  <!-- Keep the rest very light; converter is tolerant with ALLOW_ERRORS -->
+  <iwxxm:aerodrome>
+    <iwxxm:AerodromePoint gml:id="ad-efxx">
+      <gml:identifier codeSpace="urn:icao:doc7910:2013">EFXX</gml:identifier>
+    </iwxxm:AerodromePoint>
+  </iwxxm:aerodrome>
+</iwxxm:METAR>

--- a/src/test/resources/fi/fmi/avi/archiver/file/metar-observationTime-invalid.xml
+++ b/src/test/resources/fi/fmi/avi/archiver/file/metar-observationTime-invalid.xml
@@ -16,7 +16,6 @@
     </gml:TimeInstant>
   </iwxxm:observationTime>
 
-  <!-- Keep the rest very light; converter is tolerant with ALLOW_ERRORS -->
   <iwxxm:aerodrome>
     <iwxxm:AerodromePoint gml:id="ad-efxx">
       <gml:identifier codeSpace="urn:icao:doc7910:2013">EFXX</gml:identifier>

--- a/src/test/resources/fi/fmi/avi/archiver/file/metar-observationTime.xml
+++ b/src/test/resources/fi/fmi/avi/archiver/file/metar-observationTime.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iwxxm:METAR
+  xmlns:iwxxm="http://icao.int/iwxxm/3.0"
+  xmlns:gml="http://www.opengis.net/gml/3.2"
+  xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:metce="http://def.wmo.int/metce/2013"
+  gml:id="metar-1"
+  reportStatus="NORMAL"
+  automatedStation="true"
+  permissibleUsage="OPERATIONAL">
+
+  <iwxxm:observationTime>
+    <gml:TimeInstant gml:id="ti-1">
+      <gml:timePosition>2025-09-04T10:15:00Z</gml:timePosition>
+    </gml:TimeInstant>
+  </iwxxm:observationTime>
+
+  <!-- Keep the rest very light; converter is tolerant with ALLOW_ERRORS -->
+  <iwxxm:aerodrome>
+    <iwxxm:AerodromePoint gml:id="ad-efxx">
+      <gml:identifier codeSpace="urn:icao:doc7910:2013">EFXX</gml:identifier>
+    </iwxxm:AerodromePoint>
+  </iwxxm:aerodrome>
+</iwxxm:METAR>

--- a/src/test/resources/fi/fmi/avi/archiver/file/metar-observationTime.xml
+++ b/src/test/resources/fi/fmi/avi/archiver/file/metar-observationTime.xml
@@ -16,7 +16,6 @@
     </gml:TimeInstant>
   </iwxxm:observationTime>
 
-  <!-- Keep the rest very light; converter is tolerant with ALLOW_ERRORS -->
   <iwxxm:aerodrome>
     <iwxxm:AerodromePoint gml:id="ad-efxx">
       <gml:identifier codeSpace="urn:icao:doc7910:2013">EFXX</gml:identifier>

--- a/src/test/resources/fi/fmi/avi/archiver/file/speci-observationTime.xml
+++ b/src/test/resources/fi/fmi/avi/archiver/file/speci-observationTime.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iwxxm:SPECI
+  xmlns:iwxxm="http://icao.int/iwxxm/3.0"
+  xmlns:gml="http://www.opengis.net/gml/3.2"
+  gml:id="speci-1"
+  reportStatus="NORMAL"
+  permissibleUsage="OPERATIONAL">
+
+  <iwxxm:observationTime>
+    <gml:TimeInstant gml:id="ti-1">
+      <gml:timePosition>2025-09-04T12:34:56Z</gml:timePosition>
+    </gml:TimeInstant>
+  </iwxxm:observationTime>
+
+  <iwxxm:aerodrome>
+    <iwxxm:AerodromePoint gml:id="ad-efyy">
+      <gml:identifier codeSpace="urn:icao:doc7910:2013">EFYY</gml:identifier>
+    </iwxxm:AerodromePoint>
+  </iwxxm:aerodrome>
+</iwxxm:SPECI>


### PR DESCRIPTION
Implementation specifics:
* Recreates a DOM for every message in a collect document. I added a quick check on the XML string to perhaps help avoid doing unnecessary DOM builds. Not sure if it's a good idea or if there's a completely different better solution here.
* Intentionally does not use GenericAviationWeatherMessage.getMessageType() to check for METARs/SPECIs. This makes it more robust in case we're parsing messages with IWXXM versions the message converter does not yet support.