### PR TITLE
SDM-2651: Change RetryConfig.multiplier() type to OptionalDouble.

### DIFF
--- a/src/main/java/fi/fmi/avi/archiver/config/ConversionConfig.java
+++ b/src/main/java/fi/fmi/avi/archiver/config/ConversionConfig.java
@@ -15,6 +15,7 @@ public class ConversionConfig {
 
         conversionService.addConverter(new EmptyStringToEmptyMapConverter());
         conversionService.addConverter(new MapValuesToCollectionConverter(conversionService));
+        conversionService.addConverter(new NumberToOptionalDoubleConverter());
         conversionService.addConverter(new StringToDurationConverter());
         conversionService.addConverter(new StringToInstantConverter());
         conversionService.addConverter(new StringToPatternConverter());

--- a/src/main/java/fi/fmi/avi/archiver/config/factory/postaction/RetryingPostActionFactories.java
+++ b/src/main/java/fi/fmi/avi/archiver/config/factory/postaction/RetryingPostActionFactories.java
@@ -5,6 +5,7 @@ import fi.fmi.avi.archiver.util.instantiation.ObjectFactoryConfig;
 
 import java.time.Duration;
 import java.util.Optional;
+import java.util.OptionalDouble;
 
 public final class RetryingPostActionFactories {
 
@@ -15,7 +16,7 @@ public final class RetryingPostActionFactories {
     public interface RetryConfig extends ObjectFactoryConfig {
         Optional<Duration> initialInterval();
 
-        Optional<Integer> multiplier();
+        OptionalDouble multiplier();
 
         Optional<Duration> maxInterval();
 

--- a/src/main/java/fi/fmi/avi/archiver/spring/convert/NumberToOptionalDoubleConverter.java
+++ b/src/main/java/fi/fmi/avi/archiver/spring/convert/NumberToOptionalDoubleConverter.java
@@ -1,0 +1,12 @@
+package fi.fmi.avi.archiver.spring.convert;
+
+import org.springframework.core.convert.converter.Converter;
+
+import java.util.OptionalDouble;
+
+public class NumberToOptionalDoubleConverter implements Converter<Number, OptionalDouble> {
+    @Override
+    public OptionalDouble convert(final Number source) {
+        return OptionalDouble.of(source.doubleValue());
+    }
+}

--- a/src/test-integration/resources/application-SwimRabbitMQPublisherFactoryIntegrationTest.yml
+++ b/src/test-integration/resources/application-SwimRabbitMQPublisherFactoryIntegrationTest.yml
@@ -47,7 +47,7 @@ production-line:
               q-testarg-2: q-testarg-2-value
         retry:
           initialInterval: PT0.1S
-          multiplier: 2
+          multiplier: 2.0
           maxInterval: PT30S
           timeout: PT2M
         message:


### PR DESCRIPTION
`Optional<Integer>` was a somewhat coarse type for a backoff time multiplier.